### PR TITLE
test/Makefile.am: Fix build with builddir neq srcdir

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,9 +1,9 @@
 noinst_PROGRAMS = iniexample parse
 
 iniexample_SOURCES = iniexample.c
-iniexample_CFLAGS = -I../src
-iniexample_LDADD = -L../src -liniparser
+iniexample_CFLAGS = -I$(top_srcdir)/src
+iniexample_LDADD = -L$(top_builddir)/src -liniparser
 
 parse_SOURCES = parse.c
-parse_CFLAGS = -I../src
-parse_LDADD = -L../src -liniparser
+parse_CFLAGS = -I$(top_srcdir)/src
+parse_LDADD = -L$(top_builddir)/src -liniparser


### PR DESCRIPTION
Header files from src/ are not copied to builddir, and we need to
explicitly state to use the srcdir as prefix, otherwise builddir is used
as CWD and the headers are not found.

For LDADD, we want the build-time gnerated object files, so we want to
take them from builddir.